### PR TITLE
fix: avoid duplicate tcp_bbr module entries

### DIFF
--- a/3x-ui-auto-install.sh
+++ b/3x-ui-auto-install.sh
@@ -162,7 +162,10 @@ EOF
 
 print_msg "Проверка и включение BBR..."
 modprobe tcp_bbr
-echo 'tcp_bbr' | tee -a /etc/modules-load.d/modules.conf
+
+if ! grep -qx 'tcp_bbr' /etc/modules-load.d/modules.conf 2>/dev/null; then
+    echo 'tcp_bbr' | tee -a /etc/modules-load.d/modules.conf > /dev/null
+fi
 
 # Проверка BBR
 echo ""


### PR DESCRIPTION
### Motivation
- Предотвратить накопление повторяющихся строк `tcp_bbr` в `/etc/modules-load.d/modules.conf` при многократных запусках инсталлятора, чтобы сохранить конфигурационный файл аккуратным и избежать потенциальных проблем при чтении.

### Description
- Добавлена проверка наличия строки `tcp_bbr` перед её добавлением и подавление вывода `tee`, так что запись выполняется только если строчка отсутствует: `if ! grep -qx 'tcp_bbr' /etc/modules-load.d/modules.conf 2>/dev/null; then echo 'tcp_bbr' | tee -a /etc/modules-load.d/modules.conf > /dev/null; fi`.

### Testing
- Выполнена синтаксическая проверка скрипта: `bash -n 3x-ui-auto-install.sh` — успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699760fe0ef0832081dd1c50e654a4c1)